### PR TITLE
include config page with list of services scraped

### DIFF
--- a/.github/workflows/version.yaml
+++ b/.github/workflows/version.yaml
@@ -49,4 +49,3 @@ jobs:
             echo "FullSemVer=${GITHUB_REF#refs/*/}" >> "$GITHUB_OUTPUT"
             echo "# Build version: ${GITHUB_REF#refs/*/}" >> $GITHUB_STEP_SUMMARY
           fi
-          echo '${{ toJson(github) }}' | jq .

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Expose the operator service (default port: 80) and access `/` to see the aggrega
 - `SWAGGER_OPERATOR_NAME_KEY` (default: `swagger-operator-name`)
 - `SWAGGER_OPERATOR_PORT_KEY` (default: `swagger-operator-port`)
 - `SWAGGER_OPERATOR_HEADER_KEY` (default: `swagger-operator-header`)
+- `PROXY_TIMEOUT` (default: `10`)
 - `TITLE` (default: `API Documentation`)
 
 ## Development

--- a/templates/config.html
+++ b/templates/config.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>{{ title }}</title>
+</head>
+<body>
+    <h1>{{ title }}</h1>
+    <table border="1">
+        <thead>
+            <tr>
+                <th>Name</th>
+                <th>URL</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for swagger in urls %}
+            <tr>
+                <td><pre>{{ swagger.name }}</pre></td>
+                <td><pre>{{ swagger.url }}</pre></td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</body>
+</html>


### PR DESCRIPTION
## Description

This PR should support old controllers that don't expose the header key. It also includes a config page where all services scraped are listed.

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Refactoring

## Checklist

- [x] Tests added/updated
- [x] Documentation updated (if necessary)
- [x] Code follows project standards

## How to test

Run the operator with an old controller version that doesn't expose the header key.
