### PR TITLE
replace /proxy route with something more secure

### DIFF
--- a/controller.py
+++ b/controller.py
@@ -39,10 +39,10 @@ def service_event(event, memo: kopf.Memo, logger, **kwargs):
 
 
     if event['type'] == 'DELETED':
-        if f"{namespace}/{application_name}" in memo.apps:
-            del memo.apps[f"{namespace}/{application_name}"]
+        if f"{namespace}.{application_name}" in memo.apps:
+            del memo.apps[f"{namespace}.{application_name}"]
     else:
-        memo.apps.update({f"{namespace}/{application_name}": {
+        memo.apps.update({f"{namespace}.{application_name}": {
             'url': urlunparse(application_url),
             'name': application_name,
             'header': annotations.get(name_header, ""),
@@ -55,3 +55,6 @@ def service_event(event, memo: kopf.Memo, logger, **kwargs):
         with open('static/openapi/urls.json', 'w') as file:
             json.dump(urls, file, indent=2)
             logger.info("URLs written to file.")
+        with open('static/openapi/services.json', 'w') as file:
+            json.dump(memo.apps, file, indent=2)
+            logger.info("Services written to file.")

--- a/server.py
+++ b/server.py
@@ -150,8 +150,8 @@ async def config(request: Request, user=Depends(require_login)):
     Configuration page for the OpenAPI URLs.
     """
     try:
-        with open('static/openapi/urls.json') as f:
-            swaggers = json.load(f)
+        with open('static/openapi/services.json') as f:
+            swaggers = json.load(f).values()
     except Exception as e:
         logger.error(f"Error loading configuration file: {e}")
         swaggers = []

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -32,7 +32,7 @@ def test_path_without_slash(fake_memo):
     logger = MagicMock()
     with patch("builtins.open"), patch("json.dump"):
         service_event(event, fake_memo, logger)
-    key = "default/my-app"
+    key = "default.my-app"
     assert key in fake_memo.apps
     # The final path should contain the original path
     assert fake_memo.apps[key]['url'].endswith("/openapi.json")
@@ -43,7 +43,7 @@ def test_path_with_slash(fake_memo):
     logger = MagicMock()
     with patch("builtins.open"), patch("json.dump"):
         service_event(event, fake_memo, logger)
-    key = "default/my-app"
+    key = "default.my-app"
     assert key in fake_memo.apps
     assert fake_memo.apps[key]['url'].endswith("/openapi.json")
 
@@ -53,7 +53,7 @@ def test_path_with_host(fake_memo):
     logger = MagicMock()
     with patch("builtins.open"), patch("json.dump"):
         service_event(event, fake_memo, logger)
-    key = "default/my-app"
+    key = "default.my-app"
     assert key in fake_memo.apps
     # The host should be preserved
     assert fake_memo.apps[key]['url'].startswith("http://myhost")
@@ -72,7 +72,7 @@ def test_missing_annotation(fake_memo):
 
 def test_service_event_deleted(fake_memo):
     # Pre-add an app to memo
-    fake_memo.apps["default/my-app"] = {
+    fake_memo.apps["default.my-app"] = {
         "url": "http://dummy",
         "name": "my-app",
         "header": "X-API-KEY"
@@ -96,4 +96,4 @@ def test_service_event_deleted(fake_memo):
     with patch("builtins.open"), patch("json.dump"):
         service_event(event, fake_memo, logger)
     # Should remove the app from memo
-    assert "default/my-app" not in fake_memo.apps
+    assert "default.my-app" not in fake_memo.apps

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,8 +1,7 @@
 import json
 from unittest.mock import patch, mock_open, MagicMock
 from fastapi.testclient import TestClient
-from server import app, apply_proxy_to_openapi
-from urllib.parse import unquote
+from server import app
 
 import pytest
 
@@ -13,13 +12,13 @@ def set_proxy_timeout(monkeypatch):
     monkeypatch.setenv("PROXY_TIMEOUT", "1")
 
 def test_services_invalid_name():
-    # Testa erro ao passar um nome inválido
-    response = client.get("/services/inexistente")
+    # Tests error when passing an invalid service name
+    response = client.get("/services/i-dont-exist")
     assert response.status_code == 404
     assert "Service not found" in response.text
 
 def test_services_json_response():
-    # Testa se retorna JSON corretamente
+    # Tests if JSON is returned correctly
     mock_response = MagicMock()
     mock_response.content = b'{"openapi": "3.0.0"}'
     mock_response.headers = {"content-type": "application/json"}
@@ -31,7 +30,7 @@ def test_services_json_response():
         assert response.json() == {"openapi": "3.0.0"}
 
 def test_services_yaml_response():
-    # Testa se retorna YAML corretamente
+    # Tests if YAML is returned correctly
     yaml_content = """
 openapi: 3.0.0
 info:
@@ -50,7 +49,7 @@ paths: {}
         assert "openapi: 3.0.0" in response.text
 
 def test_services_unsupported_content_type():
-    # Testa erro para content-type não suportado
+    # Tests error for unsupported content-type
     mock_response = MagicMock()
     mock_response.content = b"not supported"
     mock_response.headers = {"content-type": "text/plain"}
@@ -61,20 +60,20 @@ def test_services_unsupported_content_type():
         assert "Unsupported content type" in response.text
 
 def test_docs_returns_html():
-    # Testa se a rota principal retorna HTML
+    # Tests if the main route returns HTML
     response = client.get("/")
     assert response.status_code == 200
     assert "text/html" in response.headers["content-type"]
 
 def test_docs_file_not_found(monkeypatch):
-    # Simula FileNotFoundError ao abrir o arquivo
+    # Simulates FileNotFoundError when opening the file
     with patch("builtins.open", side_effect=FileNotFoundError):
         response = client.get("/")
         assert response.status_code == 500
         assert "Error loading services file" in response.text
 
 def test_docs_json_decode_error(monkeypatch):
-    # Simula erro de JSON inválido ao abrir o arquivo
+    # Simulates invalid JSON error when opening the file
     m = mock_open(read_data="not a json")
     with patch("builtins.open", m):
         with patch("json.load", side_effect=json.JSONDecodeError("msg", "doc", 0)):
@@ -83,42 +82,9 @@ def test_docs_json_decode_error(monkeypatch):
             assert "Error loading services file" in response.text
 
 def test_config_json_decode_error():
-    # Simula erro de JSON inválido ao abrir o arquivo de config
+    # Simulates invalid JSON error when opening the config file
     m = mock_open(read_data="not a json")
     with patch("builtins.open", m):
         with patch("json.load", side_effect=Exception("invalid json")):
             response = client.get("/config")
             assert response.status_code == 200
-
-def test_apply_proxy_to_openapi_with_http():
-    url = "http://example.com/openapi.json"
-    header = {"Authorization": "Bearer token"}
-    result = apply_proxy_to_openapi(url, header)
-    assert result.startswith("/proxy?url=http://example.com/openapi.json")
-    assert "headers=" in result
-    headers_param = result.split("headers=")[1]
-    decoded = json.loads(unquote(headers_param))
-    assert decoded == header
-
-def test_apply_proxy_to_openapi_with_http_no_headers():
-    url = "http://example.com/openapi.json"
-    result = apply_proxy_to_openapi(url)
-    assert result == f"/proxy?url={url}"
-
-def test_apply_proxy_to_openapi_with_non_http_url():
-    url = "/local/openapi.json"
-    result = apply_proxy_to_openapi(url)
-    assert result == url
-
-def test_apply_proxy_to_openapi_with_empty_header():
-    url = "http://example.com/openapi.json"
-    result = apply_proxy_to_openapi(url, {})
-    assert result == f"/proxy?url={url}"
-
-def test_apply_proxy_to_openapi_with_special_characters_in_header():
-    url = "http://example.com/openapi.json"
-    header = {"X-Test": "çãõ@#%&"}
-    result = apply_proxy_to_openapi(url, header)
-    headers_param = result.split("headers=")[1]
-    decoded = json.loads(unquote(headers_param))
-    assert decoded == header

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -4,44 +4,34 @@ from fastapi.testclient import TestClient
 from server import app, apply_proxy_to_openapi
 from urllib.parse import unquote
 
+import pytest
+
 client = TestClient(app)
 
-def test_proxy_invalid_url():
-    # Tests error when passing an invalid URL
-    response = client.get("/proxy", params={"url": "http://invalid-url"})
-    assert response.status_code == 500
-    assert "Failed to fetch OpenAPI document" in response.text
+@pytest.fixture(autouse=True)
+def set_proxy_timeout(monkeypatch):
+    monkeypatch.setenv("PROXY_TIMEOUT", "1")
 
-def test_docs_returns_html():
-    # Tests if the main route returns HTML
-    response = client.get("/")
-    assert response.status_code == 200
-    assert "text/html" in response.headers["content-type"]
+def test_services_invalid_name():
+    # Testa erro ao passar um nome inválido
+    response = client.get("/services/inexistente")
+    assert response.status_code == 404
+    assert "Service not found" in response.text
 
-def test_proxy_with_headers():
-    url = "http://example.com/openapi.json"
-    headers_dict = {"Authorization": "Bearer token123"}
-    headers_encoded = json.dumps(headers_dict)  # The endpoint expects headers already in JSON
-
+def test_services_json_response():
+    # Testa se retorna JSON corretamente
     mock_response = MagicMock()
     mock_response.content = b'{"openapi": "3.0.0"}'
-    mock_response.text = '{"openapi": "3.0.0"}'
     mock_response.headers = {"content-type": "application/json"}
 
-    with patch("server.requests.get", return_value=mock_response) as mock_get:
-        response = client.get("/proxy", params={"url": url, "headers": headers_encoded})
+    with patch("server.requests.get", return_value=mock_response):
+        response = client.get("/services/default.nginx")
         assert response.status_code == 200
+        assert response.headers["content-type"].startswith("application/json")
         assert response.json() == {"openapi": "3.0.0"}
-        mock_get.assert_called_once()
-        # Checks if the headers were passed correctly
-        called_headers = mock_get.call_args[1]["headers"]
-        assert called_headers == headers_dict
 
-def test_proxy_yaml_response():
-    url = "http://example.com/openapi.yaml"
-    headers_dict = {"Authorization": "Bearer token123"}
-    headers_json = json.dumps(headers_dict)
-
+def test_services_yaml_response():
+    # Testa se retorna YAML corretamente
     yaml_content = """
 openapi: 3.0.0
 info:
@@ -51,37 +41,49 @@ paths: {}
 """
     mock_response = MagicMock()
     mock_response.content = yaml_content.encode("utf-8")
-    mock_response.text = yaml_content
     mock_response.headers = {"content-type": "application/yaml"}
 
-    with patch("server.requests.get", return_value=mock_response) as mock_get:
-        response = client.get("/proxy", params={"url": url, "headers": headers_json})
+    with patch("server.requests.get", return_value=mock_response):
+        response = client.get("/services/default.timeout")
         assert response.status_code == 200
         assert response.headers["content-type"].startswith("text/yaml")
         assert "openapi: 3.0.0" in response.text
-        mock_get.assert_called_once()
-        called_headers = mock_get.call_args[1]["headers"]
-        assert called_headers == headers_dict
+
+def test_services_unsupported_content_type():
+    # Testa erro para content-type não suportado
+    mock_response = MagicMock()
+    mock_response.content = b"not supported"
+    mock_response.headers = {"content-type": "text/plain"}
+
+    with patch("server.requests.get", return_value=mock_response):
+        response = client.get("/services/default.nginx")
+        assert response.status_code == 400
+        assert "Unsupported content type" in response.text
+
+def test_docs_returns_html():
+    # Testa se a rota principal retorna HTML
+    response = client.get("/")
+    assert response.status_code == 200
+    assert "text/html" in response.headers["content-type"]
 
 def test_docs_file_not_found(monkeypatch):
-    # Simulates FileNotFoundError when opening the file
+    # Simula FileNotFoundError ao abrir o arquivo
     with patch("builtins.open", side_effect=FileNotFoundError):
         response = client.get("/")
-        assert response.status_code == 200
-        # Should contain the default aggregator name
-        assert "Swagger Aggregator" in response.text
+        assert response.status_code == 500
+        assert "Error loading services file" in response.text
 
 def test_docs_json_decode_error(monkeypatch):
-    # Simulates invalid JSON error when opening the file
+    # Simula erro de JSON inválido ao abrir o arquivo
     m = mock_open(read_data="not a json")
     with patch("builtins.open", m):
         with patch("json.load", side_effect=json.JSONDecodeError("msg", "doc", 0)):
             response = client.get("/")
-            assert response.status_code == 200
-            assert "Swagger Aggregator" in response.text
+            assert response.status_code == 500
+            assert "Error loading services file" in response.text
 
 def test_config_json_decode_error():
-    # Simulates invalid JSON error when opening the file
+    # Simula erro de JSON inválido ao abrir o arquivo de config
     m = mock_open(read_data="not a json")
     with patch("builtins.open", m):
         with patch("json.load", side_effect=Exception("invalid json")):
@@ -94,17 +96,6 @@ def test_apply_proxy_to_openapi_with_http():
     result = apply_proxy_to_openapi(url, header)
     assert result.startswith("/proxy?url=http://example.com/openapi.json")
     assert "headers=" in result
-    headers_param = result.split("headers=")[1]
-    decoded = json.loads(unquote(headers_param))  # Fixed here!
-    assert decoded == header
-
-def test_apply_proxy_to_openapi_with_http_and_headers():
-    url = "http://example.com/openapi.json"
-    header = {"Authorization": "Bearer token"}
-    result = apply_proxy_to_openapi(url, header)
-    assert result.startswith("/proxy?url=http://example.com/openapi.json")
-    assert "headers=" in result
-    # Decodes and checks the header
     headers_param = result.split("headers=")[1]
     decoded = json.loads(unquote(headers_param))
     assert decoded == header
@@ -122,7 +113,6 @@ def test_apply_proxy_to_openapi_with_non_http_url():
 def test_apply_proxy_to_openapi_with_empty_header():
     url = "http://example.com/openapi.json"
     result = apply_proxy_to_openapi(url, {})
-    # Should not add headers if the dict is empty
     assert result == f"/proxy?url={url}"
 
 def test_apply_proxy_to_openapi_with_special_characters_in_header():


### PR DESCRIPTION
## Description

This PR refactors the API to remove the generic /proxy route and introduces a new, more explicit /services/{name} route. The {name} parameter corresponds to a key in the services.json file, allowing for more controlled and secure access to registered OpenAPI service endpoints.

Main Changes
- Removed the /proxy endpoint and all related logic.
- Added a new /services/{name} endpoint that:
- Looks up the service configuration by name in services.json.
- Forwards requests to the configured URL, applying any custom headers.
- Returns the OpenAPI spec as JSON or YAML, depending on the upstream content type.
- Returns appropriate error codes for missing services or unsupported content types.
- Updated the controller logic and tests to use the new {namespace}.{name} key format for services.
- Refactored tests to mock requests to the new /services/{name} endpoint and removed all references to /proxy.
- Improved error handling and logging for missing or invalid service definitions.
- Updated the main page and configuration page to use the new service structure.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Documentation
- [x] Refactoring

## Checklist

- [x] Tests added/updated
- [x] Documentation updated (if necessary)
- [x] Code follows project standards

